### PR TITLE
Allow psr/log v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=8.1",
         "ext-mbstring": "*",
         "brick/math": "^0.12 || ^0.13",
-        "psr/log": "^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "rowbot/idna": "^0.3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Not allowing psr/log v2 blocks the installation of this library in some major PHP libraries, e.g. Sylius v1. I am hoping for this change to be merged :-)